### PR TITLE
Prevent webrtc from calling setConfiguration internally

### DIFF
--- a/sdk/objc/components/audio/RTCAudioSession.mm
+++ b/sdk/objc/components/audio/RTCAudioSession.mm
@@ -703,15 +703,15 @@ NSString * const kRTCAudioSessionOutputVolumeSelector = @"outputVolume";
   NSError *error = nil;
   RTCAudioSessionConfiguration *webRTCConfig =
       [RTCAudioSessionConfiguration webRTCConfiguration];
-  if (![self setConfiguration:webRTCConfig active:YES error:&error]) {
-    RTCLogError(@"Failed to set WebRTC audio configuration: %@",
-                error.localizedDescription);
-    // Do not call setActive:NO if setActive:YES failed.
-    if (outError) {
-      *outError = error;
-    }
-    return NO;
-  }
+//  if (![self setConfiguration:webRTCConfig active:YES error:&error]) {
+//    RTCLogError(@"Failed to set WebRTC audio configuration: %@",
+//                error.localizedDescription);
+//    // Do not call setActive:NO if setActive:YES failed.
+//    if (outError) {
+//      *outError = error;
+//    }
+//    return NO;
+//  }
 
   // Ensure that the device currently supports audio input.
   // TODO(tkchin): Figure out if this is really necessary.


### PR DESCRIPTION
We are already setting the config in react native webrtc here: https://github.com/jive/react-native-webrtc/blob/master/ios/RCTWebRTC/RTCAudioSession%2BAdditions.swift#L56